### PR TITLE
libsensors: don't floor accelerometer value

### DIFF
--- a/libsensors/AccelSensor.cpp
+++ b/libsensors/AccelSensor.cpp
@@ -111,7 +111,7 @@ int AccelSensor::setDelay(int32_t handle, int64_t ns)
     fd = open(input_sysfs_path, O_RDWR);
     if (fd >= 0) {
         char buf[80];
-        sprintf(buf, "%lld", ns / 10000000 * 10); // Some flooring to match stock value
+        sprintf(buf, "%lld", ns);
         write(fd, buf, strlen(buf)+1);
         close(fd);
         return 0;


### PR DESCRIPTION
this is a leftover from t0, here it causes broken autorotate
and slow response times on the lockscreen

Change-Id: I30d682a65447d7f846d277ca4f9b63315b2ca526