### PR TITLE
i9300: libsensors: use CLOCK_BOOTTIME, not CLOCK_MONOTONIC

### DIFF
--- a/libsensors/SensorBase.cpp
+++ b/libsensors/SensorBase.cpp
@@ -86,7 +86,7 @@ bool SensorBase::hasPendingEvents() const {
 int64_t SensorBase::getTimestamp() {
     struct timespec t;
     t.tv_sec = t.tv_nsec = 0;
-    clock_gettime(CLOCK_MONOTONIC, &t);
+    clock_gettime(CLOCK_BOOTTIME, &t);
     return int64_t(t.tv_sec)*1000000000LL + t.tv_nsec;
 }
 


### PR DESCRIPTION
Change-Id: Ib3d5596e694ff553ed843cc7ff3525c73944ef6c