### PR TITLE
Merge pull request #15 from CyanogenMod/cm-13.0

### DIFF
--- a/libsensors/SensorBase.cpp
+++ b/libsensors/SensorBase.cpp
@@ -86,7 +86,7 @@ bool SensorBase::hasPendingEvents() const {
 int64_t SensorBase::getTimestamp() {
     struct timespec t;
     t.tv_sec = t.tv_nsec = 0;
-    clock_gettime(CLOCK_MONOTONIC, &t);
+    clock_gettime(CLOCK_BOOTTIME, &t);
     return int64_t(t.tv_sec)*1000000000LL + t.tv_nsec;
 }
 


### PR DESCRIPTION
i9300: libsensors: use CLOCK_BOOTTIME, not CLOCK_MONOTONIC