### PR TITLE
i9300: more memory tweaks

### DIFF
--- a/rootdir/fstab.smdk4x12
+++ b/rootdir/fstab.smdk4x12
@@ -20,4 +20,4 @@
 /dev/block/mmcblk0p7		/modem				emmc		defaults		recoveryonly
 
 # zram
-/dev/block/zram0			none				swap		defaults		zramsize=268435456
+/dev/block/zram0			none				swap		defaults		zramsize=419430400

--- a/rootdir/init.target.rc
+++ b/rootdir/init.target.rc
@@ -34,6 +34,22 @@ on init
     chown system system /sys/devices/system/cpu/cpufreq/pegasusq/max_cpu_lock
     chown system system /sys/devices/system/cpu/cpufreq/pegasusq/sampling_rate
 
+on boot
+    # Flash storage isn't a good entropy source, and only causes
+    # locking overhead in the kernel. Turn it off.
+    write /sys/block/mmcblk0/queue/add_random 0
+    write /sys/block/mmcblk1/queue/add_random 0
+
+    # KSM
+    write /sys/kernel/mm/ksm/deferred_timer 1
+    write /sys/kernel/mm/ksm/pages_to_scan 100
+    write /sys/kernel/mm/ksm/sleep_millisecs 500
+    write /sys/kernel/mm/ksm/run 1
+
+    # Swapping 1 page at a time is ok
+    write /proc/sys/vm/page-cluster 0
+
+    write /proc/sys/vm/swappiness 100
 
 
 


### PR DESCRIPTION
some users are seeing OOMs. Enable KSM, bump up zram and be more
aggressive about swapping.

Some of these values are taken from "Android Memory Tuning":
https://01.org/android-ia/user-guides/android-memory-tuning-android-5.0-and-5.1

Change-Id: Id950c473a5de29bb0e1e2f0a1d3602ddb982e663