### PR TITLE
i9300: destroy surface after detaching context in colorfade

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,5 +1,5 @@
 #
-# system.prop for smdk4x12
+# system.prop for i9300
 #
 
 dalvik.vm.dexopt-data-only=1
@@ -8,3 +8,6 @@ rild.libpath=/system/lib/libsecril-shim.so
 rild.libargs=-d /dev/ttyS0
 ro.sf.lcd_density=320
 ro.lcd_min_brightness=20
+
+# EGL blobs crash on screen off
+ro.egl.destroy_after_detach=true


### PR DESCRIPTION
* we use our own system.prop, this needs to be set here

Change-Id: Ica57aa82687f7a93897aaa2f0f22929cf93f1af5