### PR TITLE
i9300: remove old lmk config

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -242,24 +242,6 @@
     <!-- Allow the menu hard key to be disabled in LockScreen on some devices -->
     <bool name="config_disableMenuKeyInLockScreen">true</bool>
 
-    <!-- Device configuration setting the minfree tunable in the lowmemorykiller in the kernel.
-         A high value will cause the lowmemorykiller to fire earlier, keeping more memory
-         in the file cache and preventing I/O thrashing, but allowing fewer processes to
-         stay in memory.  A low value will keep more processes in memory but may cause
-         thrashing if set too low.  Overrides the default value chosen by ActivityManager
-         based on screen size and total memory for the largest lowmemorykiller bucket, and
-         scaled proportionally to the smaller buckets.  -1 keeps the default. -->
-    <integer name="config_lowMemoryKillerMinFreeKbytesAbsolute">122880</integer>
-
-    <!-- Device configuration adjusting the minfree tunable in the lowmemorykiller in the
-         kernel.  A high value will cause the lowmemorykiller to fire earlier, keeping more
-         memory in the file cache and preventing I/O thrashing, but allowing fewer processes
-         to stay in memory.  A low value will keep more processes in memory but may cause
-         thrashing if set too low.  Directly added to the default value chosen by
-         ActivityManager based on screen size and total memory for the largest lowmemorykiller
-         bucket, and scaled proportionally to the smaller buckets. 0 keeps the default. -->
-    <integer name="config_lowMemoryKillerMinFreeKbytesAdjust">0</integer>
-
     <!-- Hardware keys present on the device, stored as a bit field.
          This integer should equal the sum of the corresponding value for each
          of the following keys present:


### PR DESCRIPTION
this probably isn't necessary after the big batch of LMK updates earlier
this year

Change-Id: I159255ab487de3fd9ab4988ab022ad88be65e4dc