### PR TITLE
Revert "i9300: enable wideband audio hack"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -2,7 +2,6 @@
 # system.prop for i9300
 #
 
-audio.force_wideband=true
 config.disable_atlas=true
 dalvik.vm.dexopt-data-only=1
 dalvik.vm.dex2oat-Xmx=256m


### PR DESCRIPTION
* enforce some known-good basebands instead

This reverts commit 612e761571f612935b72c04e6ae1cb5c58dbee8e.

Change-Id: Ic05359400b7d51a4cf4c3baf2030fb4cb21f8982