### PR TITLE
Revert "i9300: mqanelements should actually be 4"

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -7,6 +7,7 @@ dalvik.vm.dexopt-data-only=1
 dalvik.vm.dex2oat-Xmx=256m
 rild.libpath=/system/lib/libsecril-shim.so
 rild.libargs=-d /dev/ttyS0
+ro.ril.telephony.mqanelements=5
 ro.sf.lcd_density=320
 ro.lcd_min_brightness=20
 


### PR DESCRIPTION
This reverts commit 2a12d023390e1d1477728ff1cd8f665a394a8ce9.

Change-Id: Ia83b6f7ae78378082ff77b1fa384789706f0f246